### PR TITLE
For some reason this is needed using openni

### DIFF
--- a/conf/detection.ros.ork
+++ b/conf/detection.ros.ork
@@ -15,6 +15,8 @@ source1:
     rgb_frame_id: 'camera_rgb_optical_frame'
     rgb_camera_info: '/camera/rgb/camera_info'
     rgb_image_topic: '/camera/rgb/image_raw'
+    depth_image_topic: '/camera/depth/image_raw'
+    depth_camera_info: '/camera/depth/camera_info'
 
 sink1:
   type: 'Publisher'


### PR DESCRIPTION
This is just a workaround, the real problem is that the default values expect depth_registered stuff:

```
[ INFO] [1395248076.002277778]: Subscribed to topic:/camera/rgb/camera_info with queue size of 1
[ INFO] [1395248076.003073369]: Subscribed to topic:/camera/rgb/image_raw with queue size of 1
[ INFO] [1395248076.003968179]: Subscribed to topic:/camera/depth_registered/camera_info with queue size of 1
[ INFO] [1395248076.004994459]: Subscribed to topic:/camera/depth_registered/image_raw with queue size of 1
```

Using openni2 this is not a problem as it's published by default but using openni those are not published, so this workarounds that.
