### PR TITLE
Fix seg fault while detecting objects

### DIFF
--- a/src/detection/DescriptorMatcher.cpp
+++ b/src/detection/DescriptorMatcher.cpp
@@ -211,7 +211,7 @@ namespace tod
         matcher_->knnMatch(descriptors, matches, 5);
         for (size_t i = 0; i < matches.size(); ++i)
         {
-          for(int j = 0; j < 5; ++j)
+          for(size_t j = 0; j < std::min(matches[i].size(), (size_t)5); ++j)
             if (matches[i][j].distance > radius_)
             {
               matches[i].resize(j);


### PR DESCRIPTION
In many cases, matches[i] contains less than 5 elements (varies seemingly random between 0 and 4)

Long history available [here](https://github.com/plasmodic/ecto_opencv/commit/2f2fe7fb75d09337c1d594cee416bd948f337b30#commitcomment-10687068)